### PR TITLE
Fix dockefile: coudl not start because config file is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /app
 ENV NODE_ENV production
 
 COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/next-i18next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
Fix one issue with missing config file in docker file.
<img width="710" alt="docker-compose" src="https://user-images.githubusercontent.com/429706/137597754-83747eb6-85ea-450a-908b-6e95d39ea478.png">


It doesn't fix all the issues with docker. More PRs will come.