### PR TITLE
Fix 'Failed to load SWC binary' issue in Docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY calendso/package.json calendso/yarn.lock ./
 COPY calendso/prisma prisma
 RUN yarn install --frozen-lockfile
 
-FROM node:14-alpine as builder
+FROM node:14 as builder
 WORKDIR /app
 COPY calendso .
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
The Docker build process currently fails with the following exception:

```
#15 5.672 Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /app/node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node)
#15 5.672     at Object.Module._extensions..node (internal/modules/cjs/loader.js:1144:18)
#15 5.672     at Module.load (internal/modules/cjs/loader.js:950:32)
#15 5.672     at Function.Module._load (internal/modules/cjs/loader.js:790:12)
#15 5.672     at Module.require (internal/modules/cjs/loader.js:974:19)
#15 5.672     at require (internal/modules/cjs/helpers.js:93:18)
#15 5.672     at Object.<anonymous> (/app/node_modules/next/dist/build/swc/index.js:29:20)
#15 5.672     at Module._compile (internal/modules/cjs/loader.js:1085:14)
#15 5.672     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
#15 5.672     at Module.load (internal/modules/cjs/loader.js:950:32)
#15 5.672     at Function.Module._load (internal/modules/cjs/loader.js:790:12) {
#15 5.672   code: 'ERR_DLOPEN_FAILED'
#15 5.672 }
#15 5.672 error - Failed to load SWC binary, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
```

The change I made fixes the build process. Apparently the Node Alpine image does not contain the needed binaries to build the project. This change does not affect the final image size as only the builder stage was changed.