### PR TITLE
Update dockerfile and env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,10 @@ POSTGRES_USER=unicorn_user
 POSTGRES_PASSWORD=magical_password
 POSTGRES_DB=calendso
 DATABASE_HOST=db:5432
-DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}"
-GOOGLE_API_CREDENTIALS='secret'
-BASE_URL='http://localhost:3000'
-NEXTAUTH_URL='http://localhost:3000'
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
+GOOGLE_API_CREDENTIALS={}
+BASE_URL=http://localhost:3000
+NEXTAUTH_URL=http://localhost:3000
 
 # Remove this var if you don't want Calendso to collect anonymous usage
 NEXT_PUBLIC_TELEMETRY_KEY=js.2pvs2bbpqq1zxna97wcml.oi2jzirnbj1ev4tc57c5r
@@ -30,16 +30,16 @@ ZOOM_CLIENT_SECRET=
 
 # E-mail settings
 # Configures the global From: header whilst sending emails.
-EMAIL_FROM='notifications@example.com'
+EMAIL_FROM=notifications@example.com
 
 # Configure SMTP settings (@see https://nodemailer.com/smtp/).
-EMAIL_SERVER_HOST='smtp.example.com'
+EMAIL_SERVER_HOST=smtp.example.com
 EMAIL_SERVER_PORT=587
-EMAIL_SERVER_USER='email_user'
-EMAIL_SERVER_PASSWORD='email_password'
+EMAIL_SERVER_USER=email_user
+EMAIL_SERVER_PASSWORD=email_password
 
 # Encryption key that will be used to encrypt CalDAV credentials, choose a random string, for example with `dd if=/dev/urandom bs=1K count=1 | md5sum`
-CALENDSO_ENCRYPTION_KEY=''
+CALENDSO_ENCRYPTION_KEY=
 
 JWT_SECRET=secret
 NODE_ENV=production

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
+# Set this value to 'agree' to accept our license: 
+# LICENSE: https://github.com/calendso/calendso/blob/main/LICENSE
+#
+# Summary of terms:
+# - The codebase has to stay open source, whether it was modified or not
+# - You can not repackage or sell the codebase
+# - Acquire a commercial license to remove these terms by emailing: license@cal.com
+NEXT_PUBLIC_LICENSE_CONSENT=''
+LICENSE=''
+
 POSTGRES_USER=unicorn_user
 POSTGRES_PASSWORD=magical_password
 POSTGRES_DB=calendso
@@ -30,3 +40,6 @@ EMAIL_SERVER_PASSWORD='email_password'
 
 # Encryption key that will be used to encrypt CalDAV credentials, choose a random string, for example with `dd if=/dev/urandom bs=1K count=1 | md5sum`
 CALENDSO_ENCRYPTION_KEY=''
+
+JWT_SECRET=secret
+NODE_ENV=production

--- a/.env.example
+++ b/.env.example
@@ -8,14 +8,15 @@
 NEXT_PUBLIC_LICENSE_CONSENT=
 LICENSE=
 
+BASE_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
 POSTGRES_USER=unicorn_user
 POSTGRES_PASSWORD=magical_password
 POSTGRES_DB=calendso
 DATABASE_HOST=db:5432
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
 GOOGLE_API_CREDENTIALS={}
-BASE_URL=http://localhost:3000
-NEXTAUTH_URL=http://localhost:3000
 
 # Remove this var if you don't want Calendso to collect anonymous usage
 NEXT_PUBLIC_TELEMETRY_KEY=js.2pvs2bbpqq1zxna97wcml.oi2jzirnbj1ev4tc57c5r

--- a/.env.example
+++ b/.env.example
@@ -41,5 +41,7 @@ EMAIL_SERVER_PASSWORD=email_password
 # Encryption key that will be used to encrypt CalDAV credentials, choose a random string, for example with `dd if=/dev/urandom bs=1K count=1 | md5sum`
 CALENDSO_ENCRYPTION_KEY=
 
+# It is highly recommended that the JWT secret must be overridden and very unique
 JWT_SECRET=secret
+
 NODE_ENV=production

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 # - The codebase has to stay open source, whether it was modified or not
 # - You can not repackage or sell the codebase
 # - Acquire a commercial license to remove these terms by emailing: license@cal.com
-NEXT_PUBLIC_LICENSE_CONSENT=''
-LICENSE=''
+NEXT_PUBLIC_LICENSE_CONSENT=
+LICENSE=
 
 POSTGRES_USER=unicorn_user
 POSTGRES_PASSWORD=magical_password

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,36 @@
-FROM node:14-alpine as deps
+FROM node:14 as deps
 
-RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY calendso/package.json calendso/yarn.lock ./
 COPY calendso/prisma prisma
 RUN yarn install --frozen-lockfile
 
-FROM node:14-alpine as builder
+FROM node:14 as builder
+
 WORKDIR /app
+ARG BASE_URL
+ENV BASE_URL $BASE_URL
+ARG NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_APP_URL $NEXT_PUBLIC_APP_URL
+
 COPY calendso .
+
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
 
-FROM node:14-alpine as runner
+FROM node:14 as runner
 WORKDIR /app
 ENV NODE_ENV production
 
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/next-i18next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/prisma ./prisma
 COPY  scripts scripts
+
 EXPOSE 3000
 CMD ["/app/scripts/start.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
     depends_on:
       - db
+# Optional use of Prisma Studio. In production, comment out or remove the section below to prevent unwanted access to your database.
   studio:
     image: calendso/docker
     restart: always
@@ -39,5 +40,6 @@ services:
       - npx
       - prisma
       - studio
+# END SECTION: Optional use of Prisma Studio.
 volumes:
   database-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,15 +10,34 @@ services:
     ports:
       - 5432:5432
   calendso:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - BASE_URL=${BASE_URL}
+        - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
+    image: calendso/docker
     restart: always
     ports:
       - 3000:3000
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
+    depends_on:
+      - db
+  studio:
+    image: calendso/docker
+    restart: always
+    ports:
       - 5555:5555
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
     depends_on:
       - db
+    command:
+      - npx
+      - prisma
+      - studio
 volumes:
   database-data:


### PR DESCRIPTION
Testers needed!

This PR updates the dockerfile and should run properly with a static site configuration (running `yarn start` instead of the `yarn dev` workaround)

Create a .env file by copying and renaming .env.example then substituting your variables. BASE_URL and NEXT_PUBLIC_APP_URL need to be set at build time. Use `docker-compose build` to accept those env variables automatically, or pass in the env variables manually using `docker build` args.

API-related variables (like the google API key) should work at runtime.

closes #50 
closes #46 
closes #45 
related to #43 

Note: additional customization and dev experience features are expected for the future. this intentionally takes a small step forward