### PR TITLE
Make use of internal docker networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Set this value to 'agree' to accept our license: 
+# Set this value to 'agree' to accept our license:
 # LICENSE: https://github.com/calendso/calendso/blob/main/LICENSE
 #
 # Summary of terms:
@@ -14,7 +14,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 POSTGRES_USER=unicorn_user
 POSTGRES_PASSWORD=magical_password
 POSTGRES_DB=calendso
-DATABASE_HOST=db:5432
+DATABASE_HOST=database:5432
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
 GOOGLE_API_CREDENTIALS={}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,23 @@
 # Use postgres/example user/password credentials
 version: '3.1'
+
+volumes:
+  database-data:
+
+networks:
+  stack:
+    external: false
+
 services:
-  db:
+  database:
     image: postgres
     restart: always
     volumes:
       - database-data:/var/lib/postgresql/data/
     env_file: .env
-    ports:
-      - 5432:5432
+    networks:
+      - stack
+
   calendso:
     build:
       context: .
@@ -18,28 +27,31 @@ services:
         - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
     image: calendso/docker
     restart: always
+    networks:
+      - stack
     ports:
       - 3000:3000
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
     depends_on:
-      - db
+      - database
+
 # Optional use of Prisma Studio. In production, comment out or remove the section below to prevent unwanted access to your database.
   studio:
     image: calendso/docker
     restart: always
+    networks:
+      - stack
     ports:
       - 5555:5555
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
     depends_on:
-      - db
+      - database
     command:
       - npx
       - prisma
       - studio
 # END SECTION: Optional use of Prisma Studio.
-volumes:
-  database-data:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -x
 
-/app/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "db is up"
+/app/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
 npx prisma migrate deploy
 yarn start


### PR DESCRIPTION
I have added internal docker networks to prevent port conflicts at the database. Further more we are securing the database. Now we only can access it via the app or prisma studio.

I also renamed db to database because the volume variable was written out and now it is unified.