### PR TITLE
Update github workflows to push to development image to dockerhub

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Docker Login
       # You may pin to the exact commit or the version.

--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -1,0 +1,56 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and push image to GitHub container registry
+
+# Controls when the workflow will run
+on: push
+# on:
+  # release:
+    # types: [ created ]
+
+  # # Allows you to run this workflow manually from the Actions tab
+  # workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Docker Login
+      # You may pin to the exact commit or the version.
+      # uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v1.10.0
+        with:
+          # Username used to log against the Docker registry
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          # Password or personal access token used to log against the Docker registry
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          # Log out from the Docker registry at the end of a job
+          logout: true # optional, default is true
+
+      - name: Set up Docker builder
+        id: buildx
+        uses: docker/setup-buildx-action@v1.6.0
+        
+      - name: Build and push image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          # The test image is /docker and is private. final image will be /calendso and public
+          tags: docker.io/${{ secrets.DOCKER_HUB_USERNAME }}/docker:latest
+          build-args: |
+            BASE_URL=http://localhost:3000
+            NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -3,7 +3,10 @@
 name: Build and push image to DockerHub
 
 # Controls when the workflow will run
-on: push
+on:
+  push:
+    branches:
+      - main
 
 # Leaving in example for releases. Initially we simply push to 'latest'
 # on:

--- a/.github/workflows/docker-build-push-dockerhub.yml
+++ b/.github/workflows/docker-build-push-dockerhub.yml
@@ -1,9 +1,11 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build and push image to GitHub container registry
+name: Build and push image to DockerHub
 
 # Controls when the workflow will run
 on: push
+
+# Leaving in example for releases. Initially we simply push to 'latest'
 # on:
   # release:
     # types: [ created ]
@@ -49,7 +51,7 @@ jobs:
           file: ./Dockerfile
           push: true
           # The test image is /docker and is private. final image will be /calendso and public
-          tags: docker.io/${{ secrets.DOCKER_HUB_USERNAME }}/docker:latest
+          tags: docker.io/${{ secrets.DOCKER_HUB_USERNAME }}/calendso:latest
           build-args: |
             BASE_URL=http://localhost:3000
             NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 # calendso-docker
 
+This image can be found on DockerHub at [https://hub.docker.com/repository/docker/calendso/calendso](https://hub.docker.com/repository/docker/calendso/calendso)
+
 The Docker configuration for Calendso is an effort powered by people within the community. Calendso does not provide official support for Docker, but we will accept fixes and documentation. Use at your own risk.
 
 ## Requirements

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       args:
         - BASE_URL=${BASE_URL}
         - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
-    image: calendso/docker
+    image: calendso/calendso:latest
     restart: always
     networks:
       - stack
@@ -39,7 +39,7 @@ services:
 
 # Optional use of Prisma Studio. In production, comment out or remove the section below to prevent unwanted access to your database.
   studio:
-    image: calendso/docker
+    image: calendso/calendso:latest
     restart: always
     networks:
       - stack


### PR DESCRIPTION
This pushes images to the official Calendso dockerhub 
[https://hub.docker.com/repository/docker/calendso/calendso](https://hub.docker.com/repository/docker/calendso/calendso)

Note: This default image uses http://localhost:3000 as the base path by default during the build. Existing feature requests address the desire to allow this to be specified at runtime, but this PR is specifically to make an image available and is not intended to address those requests.