### PR TITLE
Example for local development with dev server and volume binding

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,8 +36,12 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
+      - NODE_ENV=development
     depends_on:
       - database
+    volumes:
+      - "./calendso:/app/"
+      - "./scripts:/app/scripts"
 
 # Optional use of Prisma Studio. In production, comment out or remove the section below to prevent unwanted access to your database.
   studio:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 set -x
+
+# # Set environment variables
+# echo NEXT_PUBLIC_APP_URL $NEXT_PUBLIC_APP_URL
+# find \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#$NEXT_PUBLIC_APP_URL#$NEXT_PUBLIC_APP_URL_SUBSTITUTE#g"
 
 /app/scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
 npx prisma migrate deploy
-yarn start
+if [[ $NODE_ENV == "development" ]]; then
+    yarn dev
+else
+    yarn start
+fi


### PR DESCRIPTION
WIP: Do Not Pull
(can be referenced as an example for issues/questions)

This pull request demonstrates running in a configuration for local development (or non-production).
Currently this is the quickest way to get up and running with minimal changes. This does require cloning the repository and running locally.

Steps to make local development or runtime configuration more accessible:

 - [x] Use NODE_ENV=development to switch to `yarn dev` instead of `yarn start`
 - [ ] Generate development stage in Dockerfile to include relevant dev files
 - [ ] Update public docker tags to have both production and non-production builds available
 - [ ] Update instructions to clarify docker for local development or non-production use
 - [ ] Add a docker-compose.override.yml file for distinct local docker-compose customization